### PR TITLE
MprRecorder - Optimized the writeBufferSilence for single channel

### DIFF
--- a/sipXmediaLib/src/mp/MprRecorder.cpp
+++ b/sipXmediaLib/src/mp/MprRecorder.cpp
@@ -524,24 +524,33 @@ UtlBoolean MprRecorder::doProcessFrame(MpBufPtr inBufs[],
 
 int MprRecorder::writeCircularBuffer(char* channelData[], int dataSize)
 {
-    OsSysLog::add(FAC_MP, PRI_INFO, "MprRecorder::doProcessFrame - TO_CIRCULAR_BUFFER, non-silence");
+    //OsSysLog::add(FAC_MP, PRI_INFO, "MprRecorder::doProcessFrame - TO_CIRCULAR_BUFFER, non-silence");
     
-    unsigned long newSize, previousSize, iterPreviousSize;
-    int bytesPerSample = getBytesPerSample(mRecFormat);
-    assert(bytesPerSample > 0);
-
-    int dataIndex;
-    int channelIndex;
-    if(bytesPerSample > 0)
+    unsigned long newSize, previousSize;
+    if (mChannels == 1)
     {
-        for(dataIndex = 0; dataIndex < dataSize; dataIndex += bytesPerSample)
+        // Be as efficient as possible for one channel (no interleaving needed)
+        mpCircularBuffer->write(channelData[0], dataSize, &newSize, &previousSize);
+    }
+    else
+    {
+        unsigned long iterPreviousSize;
+        int bytesPerSample = getBytesPerSample(mRecFormat);
+        assert(bytesPerSample > 0);
+
+        int dataIndex;
+        int channelIndex;
+        if(bytesPerSample > 0)
         {
-            for(channelIndex = 0; channelIndex < mChannels; channelIndex++)
+            for(dataIndex = 0; dataIndex < dataSize; dataIndex += bytesPerSample)
             {
-                mpCircularBuffer->write(&((channelData[channelIndex])[dataIndex]), bytesPerSample, &newSize, &iterPreviousSize);
-                if(dataIndex == 0)
+                for(channelIndex = 0; channelIndex < mChannels; channelIndex++)
                 {
-                    previousSize = iterPreviousSize;
+                    mpCircularBuffer->write(&((channelData[channelIndex])[dataIndex]), bytesPerSample, &newSize, &iterPreviousSize);
+                    if(dataIndex == 0)
+                    {
+                        previousSize = iterPreviousSize;
+                    }
                 }
             }
         }


### PR DESCRIPTION
The master branch contains generic code to interleave the multi-channel samples in MprRecorder::writeBufferSilence. This patch adds back the faster buffer copy for single-channel scenarios, keeping the multi-channel support as well.